### PR TITLE
Fix mpv command parameters

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,6 +118,9 @@ class MediaPlayer:
                 return False, "Video bulunamadı"
             video_paths = [os.path.join(VIDEO_DIR, self.videos[0])]
         else:
+            # Gelen deger tek bir dosya adi ise listeye cevir
+            if isinstance(video_list, str):
+                video_list = [video_list]
             video_paths = [os.path.join(VIDEO_DIR, v) for v in video_list]
 
         for path in video_paths:


### PR DESCRIPTION
## Summary
- handle single filename strings when playing videos
- ensure mpv receives each video file path individually

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687049cebf0083299f9a02bee4bf305f