### PR TITLE
Fix install script to create images dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ pip install -r requirements.txt
 deactivate
 
 step "4. Creating required directories"
-mkdir -p videos logs
+mkdir -p videos logs images
 
 if [ -f logo.png ]; then
   step "Setting desktop wallpaper"


### PR DESCRIPTION
## Summary
- ensure `install.sh` also creates the `images` directory

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687126944ab48329995c0bd19a0e2e32