### PR TITLE
Update systemctl status call

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ python3 -m py_compile app.py
 step "8. Starting service"
 sudo systemctl restart pi-ekran.service
 sleep 2
-sudo systemctl status pi-ekran.service --no-pager
+sudo systemctl status pi-ekran.service --no-pager || true
 
 IP=$(hostname -I | awk '{print $1}')
 echo -e "${GREEN}Installation complete. Access the web interface at: http://${IP}:5000${NC}"


### PR DESCRIPTION
## Summary
- prevent `install.sh` from exiting when `pi-ekran.service` isn't active

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68713f33ba708329a4840542a3fa8574