### PR TITLE
Load camera list on startup

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -37,6 +37,9 @@ class PiEkranController {
 
         // Videoları yükle
         this.loadVideos();
+
+        // Kameraları yükle
+        this.loadCameras();
     }
     
     bindEvents() {
@@ -264,6 +267,16 @@ class PiEkranController {
             this.renderVideoList(data.videos || []);
         } catch (e) {
             this.addLog('Video listesi alınamadı', 'error');
+        }
+    }
+
+    async loadCameras() {
+        try {
+            const response = await fetch('/cameras');
+            const data = await response.json();
+            this.renderCameraList(data.cameras || []);
+        } catch (e) {
+            this.addLog('Kamera listesi alınamadı', 'error');
         }
     }
 


### PR DESCRIPTION
## Summary
- dynamically load cameras on page startup
- ensure pages contain a camera list container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687141bf63288329b1387eed37d696ee