### PR TITLE
Improve MPV diagnostics

### DIFF
--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app
+
+# Prevent scheduler from starting during tests
+patcher = patch.object(app.MediaPlayer, "start_scheduler", lambda self: None)
+patcher.start()
+
+
+def test_play_video_mpv_missing(tmp_path):
+    config = tmp_path / "config.json"
+    config.write_text("{}")
+    with patch.object(app, "CONFIG_FILE", str(config)):
+        player = app.MediaPlayer()
+        with patch("shutil.which", return_value=None):
+            success, msg = player.play_video()
+        assert not success
+        assert "mpv" in msg
+
+
+def test_mpv_log_file_constant():
+    assert os.path.basename(app.MPV_LOG_FILE) == "mpv.log"


### PR DESCRIPTION
## Summary
- log mpv output into `logs/mpv.log`
- detect early mpv termination and report error
- add simple tests to check mpv handling

## Testing
- `pytest -q`
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6872f72625c08329a9743f15a341ae24