### PR TITLE
Add optional MPV logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,11 @@ sudo systemctl status pi-ekran.service
 journalctl -u pi-ekran.service -f
 ```
 
-### 4. Dayanıklılık Testi
+### 4. Logging Ayarları
+
+`config.json` dosyasındaki `log_level` ve `enable_mpv_logging` alanlarıyla kaydedilen log miktarını kontrol edebilirsiniz. Varsayılan olarak `enable_mpv_logging` değeri `false` olduğundan MPV'nin ayrıntılı logları yazılmaz. Daha fazla detay görmek isterseniz bu değeri `true` yapabilir ve `log_level` değerini `INFO` ya da `DEBUG` olarak değiştirebilirsiniz.
+
+### 5. Dayanıklılık Testi
 
 Pi'yi yeniden başlatın:
 ```bash

--- a/config.json
+++ b/config.json
@@ -18,6 +18,7 @@
     "web_port": 5000,
     "fallback_enabled": true,
     "log_level": "INFO",
+    "enable_mpv_logging": false,
     "schedule": [
         {
             "days": ["Tuesday", "Thursday"],


### PR DESCRIPTION
## Summary
- reduce default log level to WARNING
- allow configuring log level through `config.json`
- make MPV log generation optional via `enable_mpv_logging`
- document new logging settings

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687302f1653c8329a71213adc1186a28