### PR TITLE
Fix image paths and upload limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,6 +71,8 @@ logger = logging.getLogger("PiEkran")
 app = Flask(__name__)
 app.config["UPLOAD_FOLDER"] = VIDEO_DIR
 app.config["IMAGE_UPLOAD_FOLDER"] = IMAGE_DIR
+# Allow large uploads (e.g. up to 1GB)
+app.config["MAX_CONTENT_LENGTH"] = 1024 * 1024 * 1024
 
 # Flask-Login kurulumu
 login_manager = LoginManager()

--- a/static/script.js
+++ b/static/script.js
@@ -798,7 +798,7 @@ class PiEkranController {
         item.className = 'image-item';
 
         const img = document.createElement('img');
-        img.src = `/images/${image}`;
+        img.src = `/static/images/${image}`;
         img.alt = image;
         img.style.maxWidth = "80px";
         img.style.maxHeight = "80px";


### PR DESCRIPTION
## Summary
- fix rendering path for images to use the static folder
- allow uploading large files by increasing Flask `MAX_CONTENT_LENGTH`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687305f5c4e8832991544da526078ae1