### PR TITLE
Remove MAX_CONTENT_LENGTH to allow larger uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,8 +71,11 @@ logger = logging.getLogger("PiEkran")
 app = Flask(__name__)
 app.config["UPLOAD_FOLDER"] = VIDEO_DIR
 app.config["IMAGE_UPLOAD_FOLDER"] = IMAGE_DIR
-# Allow large uploads (e.g. up to 1GB)
-app.config["MAX_CONTENT_LENGTH"] = 1024 * 1024 * 1024
+# Remove upload size limit
+# Flask checks MAX_CONTENT_LENGTH and rejects requests larger than this
+# value with a 413 status. By not setting it we allow uploads of any size
+if "MAX_CONTENT_LENGTH" in app.config:
+    del app.config["MAX_CONTENT_LENGTH"]
 
 # Flask-Login kurulumu
 login_manager = LoginManager()


### PR DESCRIPTION
## Summary
- remove `MAX_CONTENT_LENGTH` from Flask app config so Flask does not reject large requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873089f47248329928ef808235d3a47