### PR TITLE
Fix 413 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Sistem açıldıktan sonra web arayüzünün otomatik olarak erişilebilir oldu�
 - Statik IP atayın veya router'da DHCP rezervasyonu yapın
 - `.local` alan adının çalışması için Raspberry Pi'de `avahi-daemon` kurulmuş olmalıdır. Windows istemciler için Bonjour yüklü değilse IP adresini kullanabilirsiniz.
 - Firewall'da 5000 (veya Nginx kullanıyorsanız 80) portunu açın
+- Büyük dosya yüklerken `413 Request Entity Too Large` hatası alırsanız Nginx yapılandırmasına `client_max_body_size 0;` ekleyin
 
 ### Servis Sorunları
 - Logları kontrol edin: `journalctl -u pi-ekran.service -n 50`

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,10 @@ server {
     listen 80;
     server_name eformtv.local;
 
+    # Allow large file uploads through Nginx
+    # 0 disables the limit completely; adjust as needed
+    client_max_body_size 0;
+
     location / {
         proxy_pass http://127.0.0.1:5000;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- allow large file uploads via nginx
- document how to avoid 413 errors

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68730c00d32483299bf995693aa3ec55